### PR TITLE
Allow custom templates to be cloned with `skyux new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 1.0.0-beta.4 (2017-03-15)
-
-- Added `--template` to `skyux new`.
-
 # 1.0.0-beta.3 (2017-02-17)
 
 - Removed `--noServe` from `skyux help` since it's been deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-beta.4 (2017-03-15)
+
+- Added `--template` to `skyux new`.
+
 # 1.0.0-beta.3 (2017-02-17)
 
 - Removed `--noServe` from `skyux help` since it's been deprecated.

--- a/lib/help.js
+++ b/lib/help.js
@@ -32,7 +32,7 @@ Common Options:
                     Ex: skyux serve --launch local
   -t | --template Specifies the base template to use when creating a SKY UX application.
                     The value should be the suffix of an existing SKY UX template repo.
-                    Ex: provided the repo 'https://github.com/blackbaud/skyux-template-my-team/' exists,
+                    Ex: provided the repo 'blackbaud/skyux-template-my-team/' exists,
                     type: 'skyux new --template my-team'
 `);
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -30,6 +30,10 @@ Common Options:
   -l | --launch   Specifies the URL to launch during serve.
                     Possible values are host (default), local, or none.
                     Ex: skyux serve --launch local
+  -t | --template Specifies the base template to use when creating a SKY UX application.
+                    The value should be the suffix of an existing SKY UX template repo.
+                    Ex: provided the repo 'https://github.com/blackbaud/skyux-template-my-team/' exists,
+                    type: 'skyux new --template my-team'
 `);
 
 }

--- a/lib/new.js
+++ b/lib/new.js
@@ -88,9 +88,9 @@ const cleanupTemplate = () => {
 const cloneTemplate = () => {
   logger.info(`Cloning ${settings.template.name} SKY UX template.`);
   return new Promise((resolve, reject) => {
-    clone(settings.template.repoUrl, settings.pathTmp, (err) => {
+    clone(settings.template.url, settings.pathTmp, (err) => {
       if (err) {
-        logger.info(`Template not found at location, ${settings.template.repoUrl}.`);
+        logger.info(`Template not found at location, ${settings.template.url}.`);
         reject(err);
         return;
       }
@@ -177,25 +177,23 @@ const promptForName = () => {
  * @name getTemplateFromArgs
  */
 const getTemplateFromArgs = (args) => {
-  const templateRepoBaseUrl = 'https://github.com/blackbaud/skyux-template';
-  const keys = ['template', 't'];
-  let templateName;
-  let templateRepoUrl;
+  let name = 'default';
+  let url = 'https://github.com/blackbaud/skyux-template';
 
   if (args) {
-    keys.forEach((key) => {
-      const isKeySet = (!templateName && typeof args[key] === 'string');
-      if (isKeySet) {
-        templateName = args[key];
-        templateRepoUrl = `${templateRepoBaseUrl}-${templateName}`;
-      }
-    });
+    if (args.t) {
+      args.template = args.t;
+    }
+
+    // Checks if the flag is paired with a string.
+    // (If the flag is provided without the string, it will return `true`.)
+    if (typeof args.template === 'string') {
+      name = args.template;
+      url = `${url}-${name}`;
+    }
   }
 
-  return Object.freeze({
-    name: templateName || 'default',
-    repoUrl: templateRepoUrl || templateRepoBaseUrl
-  });
+  return Object.freeze({ name, url });
 };
 
 /**

--- a/lib/new.js
+++ b/lib/new.js
@@ -19,9 +19,8 @@ const logger = require('winston');
 * Adjust package.json file.
 * Run npm install
 */
-const templateRepoUrl = 'https://github.com/blackbaud/skyux-template';
+const templateRepoBaseUrl = 'https://github.com/blackbaud/skyux-template';
 const settings = {};
-let argv;
 
 /**
  * Verifies path is empty, execpt for README.md and .git folder
@@ -46,14 +45,17 @@ const isRepoEmpty = (dir) => {
 const npmInstall = () => {
   logger.info('Running npm install');
   const npmProcess = spawn('npm', ['install'], { cwd: settings.path, stdio: 'inherit' });
-  npmProcess.on('exit', function () {
-    logger.info('SPA %s created in directory %s', settings.spa, settings.name);
-    logger.info('Change into that directory and run "skyux serve" to begin.');
+  return new Promise((resolve) => {
+    npmProcess.on('exit', () => {
+      logger.info('SPA %s created in directory %s', settings.spa, settings.name);
+      logger.info('Change into that directory and run "skyux serve" to begin.');
+      resolve();
+    });
   });
 };
 
 /**
- * Removes the .git folder.  Fixes package.json.
+ * Removes the .git folder. Fixes package.json.
  * @name cleanupTemplate
  */
 const cleanupTemplate = () => {
@@ -71,28 +73,36 @@ const cleanupTemplate = () => {
 
   fs.writeJsonSync(packagePath, packageJson);
   fs.removeSync(path.join(settings.pathTmp, '.git'));
-  fs.copy(settings.pathTmp, settings.path,  { mkdirp: true, clobber: true }, (err) => {
-    if (err) {
-      logger.error(err);
-    } else {
+
+  return new Promise((resolve, reject) => {
+    fs.copy(settings.pathTmp, settings.path, { mkdirp: true, clobber: true }, (err) => {
+      if (err) {
+        console.log('Error! cleanupTemplate', err);
+        return reject(err);
+      }
+
       fs.removeSync(settings.pathTmp);
-      npmInstall();
-    }
+      resolve();
+    });
   });
 };
 
 /**
- * Clone the template is a temp path.
+ * Clone the template into a temp path.
  * @name cloneTemplate
  */
 const cloneTemplate = () => {
-  logger.info('Cloning SKY UX template.');
-  clone(templateRepoUrl, settings.pathTmp, (err) => {
-    if (err) {
-      logger.error(err);
-    } else {
-      cleanupTemplate();
-    }
+  logger.info('Cloning SKY UX template.', settings);
+  return new Promise((resolve, reject) => {
+    clone(settings.templateRepoUrl, settings.pathTmp, (err) => {
+      if (err) {
+        console.log('Error, cloneTemplate!', err);
+        logger.error(`Template not found at location, ${settings.templateRepoUrl}.`);
+        return reject(err);
+      }
+
+      resolve();
+    });
   });
 };
 
@@ -100,51 +110,46 @@ const cloneTemplate = () => {
  * Clones the repo into the specified path
  * @name cloneRepo
  */
-const cloneRepo = () => {
+const cloneRepo = () => new Promise((resolve, reject) => {
+  if (!settings.url) {
+    return resolve();
+  }
+
   logger.info('Cloning your repository.');
   clone(settings.url, settings.path, (err) => {
     if (err) {
-      logger.error(err);
-    } else {
-      if (!isRepoEmpty(settings.path)) {
-        logger.info('skyux new only works with empty repositories.');
-      } else {
-        cloneTemplate();
-      }
+      console.log('Error! cloneRepo', err);
+      reject(err);
+      return;
     }
+
+    if (!isRepoEmpty(settings.path)) {
+      logger.info('skyux new only works with empty repositories.');
+      return;
+    }
+
+    resolve();
   });
-};
+});
 
 /**
- * Prompts for the repo URL.
+ * Prompts for the project's root repo URL.
  * @name promptForUrl
  */
 const promptForUrl = () => {
-  promptly.prompt(
-    'What is the URL to your repo? (leave this blank if you don\'t know)',
-    {
-      'default': ''
-    },
-    (err, value) => {
+  const prompt = 'What is the URL to your repo? (leave this blank if you don\'t know)';
+  return promptly.prompt(prompt, { 'default': '' })
+    .then((value) => {
       settings.url = value;
-      if (settings.url) {
-        cloneRepo();
-      } else {
-        cloneTemplate();
-      }
-    }
-  );
+      return Promise.resolve(value);
+    });
 };
 
 /**
- * Prompts for the name.
+ * Prompts for the project's root directory name.
  * @name promptForName
  */
-const promptForName = (args) => {
-
-  // Globally save any arguments
-  argv = args;
-
+const promptForName = () => {
   const prompt = 'What is the root directory for your SPA? (example: my-spa-name)';
   const validator = (value) => {
     if (!value || !value.match(/^[a-z0-9\-]*$/)) {
@@ -160,19 +165,32 @@ const promptForName = (args) => {
     return value;
   };
 
-  // No need to check for err since we're using a validator
-  const handler = (err, value) => {
-    settings.spa = value;
-    settings.name = 'skyux-spa-' + value;
-    settings.path = path.join('.', settings.name);
-    settings.pathTmp = path.join(settings.path, 'tmp');
-    promptForUrl();
-  };
-
-  promptly.prompt(prompt, { validator: validator }, handler);
+  return promptly.prompt(prompt, { validator: validator })
+    .then((value) => {
+      settings.spa = value;
+      settings.name = 'skyux-spa-' + value;
+      settings.path = path.join('.', settings.name);
+      settings.pathTmp = path.join(settings.path, 'tmp');
+      return Promise.resolve(value);
+    });
 };
 
 /**
  * ENTRY POINT
  */
-module.exports = promptForName;
+module.exports = (args) => {
+  const templateRequested = (args && args.template && args.template !== true);
+  if (templateRequested) {
+    settings.templateRepoUrl = `${templateRepoBaseUrl}-${args.template}`;
+  } else {
+    settings.templateRepoUrl = `${templateRepoBaseUrl}`;
+  }
+
+  promptForName()
+    .then(() => promptForUrl())
+    .then(() => cloneRepo())
+    .then(() => cloneTemplate())
+    .then(() => cleanupTemplate())
+    .then(() => npmInstall())
+    .catch(err => logger.error(err));
+};

--- a/lib/new.js
+++ b/lib/new.js
@@ -19,7 +19,6 @@ const logger = require('winston');
 * Adjust package.json file.
 * Run npm install
 */
-const templateRepoBaseUrl = 'https://github.com/blackbaud/skyux-template';
 const settings = {};
 
 /**
@@ -182,20 +181,28 @@ const promptForName = () => {
  * @name getTemplateFromArgs
  */
 const getTemplateFromArgs = (args) => {
-  const templateNameProvided = (args && args.template && args.template !== true);
-  let template = {
-    name: 'default',
-    repoUrl: templateRepoBaseUrl
-  };
+  const templateRepoBaseUrl = 'https://github.com/blackbaud/skyux-template';
+  const keys = ['template', 't'];
+  let templateName;
+  let templateRepoUrl;
 
-  if (templateNameProvided) {
-    template = {
-      name: args.template,
-      repoUrl: `${templateRepoBaseUrl}-${args.template}`
-    };
+  if (args) {
+    keys.forEach((key) => {
+      if (templateName) {
+        return;
+      }
+
+      if (typeof args[key] === 'string') {
+        templateName = args[key];
+        templateRepoUrl = `${templateRepoBaseUrl}-${templateName}`;
+      }
+    });
   }
 
-  return template;
+  return Object.freeze({
+    name: templateName || 'default',
+    repoUrl: templateRepoUrl || templateRepoBaseUrl
+  });
 };
 
 /**

--- a/lib/new.js
+++ b/lib/new.js
@@ -45,13 +45,12 @@ const isRepoEmpty = (dir) => {
 const npmInstall = () => {
   logger.info('Running npm install');
   const npmProcess = spawn('npm', ['install'], { cwd: settings.path, stdio: 'inherit' });
-  return new Promise((resolve) => {
-    npmProcess.on('exit', () => {
-      logger.info('SPA %s created in directory %s', settings.spa, settings.name);
-      logger.info('Change into that directory and run "skyux serve" to begin.');
-      resolve();
-    });
+  npmProcess.on('exit', () => {
+    logger.info('SPA %s created in directory %s', settings.spa, settings.name);
+    logger.info('Change into that directory and run "skyux serve" to begin.');
   });
+
+  return Promise.resolve();
 };
 
 /**
@@ -77,8 +76,8 @@ const cleanupTemplate = () => {
   return new Promise((resolve, reject) => {
     fs.copy(settings.pathTmp, settings.path, { mkdirp: true, clobber: true }, (err) => {
       if (err) {
-        console.log('Error! cleanupTemplate', err);
-        return reject(err);
+        reject(err);
+        return;
       }
 
       fs.removeSync(settings.pathTmp);
@@ -92,15 +91,16 @@ const cleanupTemplate = () => {
  * @name cloneTemplate
  */
 const cloneTemplate = () => {
-  logger.info('Cloning SKY UX template.', settings);
+  logger.info(`Cloning ${settings.template.name} SKY UX template.`);
   return new Promise((resolve, reject) => {
-    clone(settings.templateRepoUrl, settings.pathTmp, (err) => {
+    clone(settings.template.repoUrl, settings.pathTmp, (err) => {
       if (err) {
-        console.log('Error, cloneTemplate!', err);
-        logger.error(`Template not found at location, ${settings.templateRepoUrl}.`);
-        return reject(err);
+        logger.info(`Template not found at location, ${settings.template.repoUrl}.`);
+        reject(err);
+        return;
       }
 
+      logger.info(`${settings.template.name} template successfully cloned.`);
       resolve();
     });
   });
@@ -110,27 +110,28 @@ const cloneTemplate = () => {
  * Clones the repo into the specified path
  * @name cloneRepo
  */
-const cloneRepo = () => new Promise((resolve, reject) => {
+const cloneRepo = () => {
   if (!settings.url) {
-    return resolve();
+    return Promise.resolve();
   }
 
-  logger.info('Cloning your repository.');
-  clone(settings.url, settings.path, (err) => {
-    if (err) {
-      console.log('Error! cloneRepo', err);
-      reject(err);
-      return;
-    }
+  return new Promise((resolve, reject) => {
+    logger.info('Cloning your repository.');
+    clone(settings.url, settings.path, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
 
-    if (!isRepoEmpty(settings.path)) {
-      logger.info('skyux new only works with empty repositories.');
-      return;
-    }
+      if (!isRepoEmpty(settings.path)) {
+        reject('skyux new only works with empty repositories.');
+        return;
+      }
 
-    resolve();
+      resolve();
+    });
   });
-});
+};
 
 /**
  * Prompts for the project's root repo URL.
@@ -176,17 +177,34 @@ const promptForName = () => {
 };
 
 /**
+ * Returns an object representing the template config, derived
+ * from constructor arguments.
+ * @name getTemplateFromArgs
+ */
+const getTemplateFromArgs = (args) => {
+  const templateNameProvided = (args && args.template && args.template !== true);
+  let template = {
+    name: 'default',
+    repoUrl: templateRepoBaseUrl
+  };
+
+  if (templateNameProvided) {
+    template = {
+      name: args.template,
+      repoUrl: `${templateRepoBaseUrl}-${args.template}`
+    };
+  }
+
+  return template;
+};
+
+/**
  * ENTRY POINT
  */
 module.exports = (args) => {
-  const templateRequested = (args && args.template && args.template !== true);
-  if (templateRequested) {
-    settings.templateRepoUrl = `${templateRepoBaseUrl}-${args.template}`;
-  } else {
-    settings.templateRepoUrl = `${templateRepoBaseUrl}`;
-  }
+  settings.template = getTemplateFromArgs(args);
 
-  promptForName()
+  return promptForName()
     .then(() => promptForUrl())
     .then(() => cloneRepo())
     .then(() => cloneTemplate())

--- a/lib/new.js
+++ b/lib/new.js
@@ -58,30 +58,29 @@ const npmInstall = () => {
  */
 const cleanupTemplate = () => {
   const packagePath = path.join(settings.pathTmp, 'package.json');
-  let packageJson = fs.readJsonSync(packagePath);
-  packageJson.name = `blackbaud-${settings.name}`;
-  packageJson.description = `Single-page-application for ${settings.name}`;
-
-  if (settings.url) {
-    packageJson.repository = {
-      type: 'git',
-      url: settings.url
-    };
-  }
-
-  fs.writeJsonSync(packagePath, packageJson);
-  fs.removeSync(path.join(settings.pathTmp, '.git'));
-
+  
   return new Promise((resolve, reject) => {
-    fs.copy(settings.pathTmp, settings.path, { mkdirp: true, clobber: true }, (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
+    let packageJson = fs.readJsonSync(packagePath);
+    packageJson.name = `blackbaud-${settings.name}`;
+    packageJson.description = `Single-page-application for ${settings.name}`;
 
+    if (settings.url) {
+      packageJson.repository = {
+        type: 'git',
+        url: settings.url
+      };
+    }
+
+    try {
+      fs.writeJsonSync(packagePath, packageJson);
+      fs.removeSync(path.join(settings.pathTmp, '.git'));
+      fs.copySync(settings.pathTmp, settings.path, { mkdirp: true, clobber: true });
       fs.removeSync(settings.pathTmp);
       resolve();
-    });
+    } catch (err) {
+      logger.info('Template cleanup failed.');
+      reject(err);
+    }
   });
 };
 
@@ -188,11 +187,8 @@ const getTemplateFromArgs = (args) => {
 
   if (args) {
     keys.forEach((key) => {
-      if (templateName) {
-        return;
-      }
-
-      if (typeof args[key] === 'string') {
+      const isKeySet = (!templateName && typeof args[key] === 'string');
+      if (isKeySet) {
         templateName = args[key];
         templateRepoUrl = `${templateRepoBaseUrl}-${templateName}`;
       }

--- a/lib/new.js
+++ b/lib/new.js
@@ -43,13 +43,23 @@ const isRepoEmpty = (dir) => {
  */
 const npmInstall = () => {
   logger.info('Running npm install');
-  const npmProcess = spawn('npm', ['install'], { cwd: settings.path, stdio: 'inherit' });
-  npmProcess.on('exit', () => {
-    logger.info('SPA %s created in directory %s', settings.spa, settings.name);
-    logger.info('Change into that directory and run "skyux serve" to begin.');
+  const npmProcess = spawn('npm', ['install'], {
+    cwd: settings.path,
+    stdio: 'inherit'
   });
 
-  return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    npmProcess.on('exit', (code) => {
+      if (code !== 0) {
+        reject('npm install failed.');
+        return;
+      }
+
+      logger.info('SPA %s created in directory %s', settings.spa, settings.name);
+      logger.info('Change into that directory and run "skyux serve" to begin.');
+      resolve();
+    });
+  });
 };
 
 /**

--- a/lib/new.js
+++ b/lib/new.js
@@ -63,13 +63,10 @@ const cleanupTemplate = () => {
     let packageJson = fs.readJsonSync(packagePath);
     packageJson.name = `blackbaud-${settings.name}`;
     packageJson.description = `Single-page-application for ${settings.name}`;
-
-    if (settings.url) {
-      packageJson.repository = {
-        type: 'git',
-        url: settings.url
-      };
-    }
+    packageJson.repository = {
+      type: 'git',
+      url: settings.url
+    };
 
     try {
       fs.writeJsonSync(packagePath, packageJson);
@@ -140,7 +137,7 @@ const promptForUrl = () => {
   return promptly.prompt(prompt, { 'default': '' })
     .then((value) => {
       settings.url = value;
-      return Promise.resolve(value);
+      return Promise.resolve();
     });
 };
 

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -71,6 +71,21 @@ describe('skyux new command', () => {
     });
   });
 
+  it('should clone the default template if template flag is used without a name', (done) => {
+    spyOn(logger, 'info');
+    const skyuxNew = require('../lib/new')({
+      template: true
+    });
+    sendLine('some-spa-name', () => {
+      sendLine('', () => {
+        skyuxNew.then(() => {
+          expect(logger.info).toHaveBeenCalledWith('default template successfully cloned.');
+          done();
+        });
+      });
+    });
+  });
+
   it('should clone the default template if custom template not provided', (done) => {
     spyOn(logger, 'info');
     const skyuxNew = require('../lib/new')();
@@ -123,7 +138,7 @@ describe('skyux new command', () => {
     spyOn(fs, 'existsSync').and.returnValue(false);
     spyOn(logger, 'error');
     const skyuxNew = require('../lib/new')({
-      template: 'invalid-template-name'
+      t: 'invalid-template-name'
     });
     sendLine('some-spa-name', () => {
       sendLine('', () => {

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -182,9 +182,7 @@ describe('skyux new command', () => {
     spyOn(fs, 'readJsonSync').and.returnValue({});
     spyOn(fs, 'writeJsonSync');
     spyOn(fs, 'removeSync');
-    spyOn(fs, 'copy').and.callFake((tmp, path, settings, cb) => {
-      cb();
-    });
+    spyOn(fs, 'copySync');
     spyOn(logger, 'info');
     const skyuxNew = require('../lib/new')();
     sendLine('some-spa-name', () => {
@@ -195,6 +193,26 @@ describe('skyux new command', () => {
           expect(logger.info).toHaveBeenCalledWith(
             'Change into that directory and run "skyux serve" to begin.'
           );
+          done();
+        });
+      });
+    });
+  });
+
+  it('should handle errors when cleaning the template', (done) => {
+    spyOn(fs, 'existsSync').and.returnValue(false);
+    spyOn(fs, 'readdirSync').and.returnValue([
+      '.git',
+      'README.md',
+      '.gitignore'
+    ]);
+    spyOn(fs, 'readJsonSync').and.returnValue({});
+    spyOn(logger, 'info');
+    const skyuxNew = require('../lib/new')();
+    sendLine('some-spa-name', () => {
+      sendLine('some-spa-repo', () => {
+        skyuxNew.then(() => {
+          expect(logger.info).toHaveBeenCalledWith('Template cleanup failed.');
           done();
         });
       });


### PR DESCRIPTION
- I may have overreached on this one; let me know. As I was adding the template features, it seemed that the steps could be isolated and presented as [a promise chain](https://github.com/blackbaud/skyux-cli/pull/114/files#diff-23e903c51c9ed276b6f2392f0c114d84R214). 
- Acceptable flags are `-t` and `--template`.
- All tests pass.
- Added entries to `skyux help`.
- To test locally: 
  - `./bin/skyux.js new -t stache`
  - `./bin/skyux.js new --template stache`
  - `./bin/skyux.js new --template asdf` <-- should fail
  - `./bin/skyux.js new --template` <-- should clone default template
  - `./bin/skyux.js new` <-- should clone default template