### PR TITLE
Coverage reporting with Cobertura and JUnit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+﻿# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to lf line endings on checkout.
+*.js text eol=lf
+*.json text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-﻿# Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
-
-# Explicitly declare text files you want to always be normalized and converted
-# to lf line endings on checkout.
-*.js text eol=lf
-*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Logs
+﻿# Logs
 logs
 *.log
 npm-debug.log*
@@ -37,3 +37,6 @@ jspm_packages
 .node_repl_history
 
 .DS_Store
+
+# Visual Studio
+.vs

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
+# Test results directory used by tools like jasmine JUnit reporter
+testresults
+
 # nyc test coverage
 .nyc_output
 

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,4 @@
-{
+﻿{
     "preset": "airbnb",
     "disallowDanglingUnderscores": null,
     "disallowTrailingWhitespace": null,
@@ -6,6 +6,7 @@
     "requireLineFeedAtFileEnd": null,
     "requireTrailingComma": null,
     "requirePaddingNewLinesBeforeLineComments": null,
+    "validateLineBreaks": null,
     "excludeFiles": [
       "coverage/**"
     ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "skyux": "bin/skyux.js"
   },
   "scripts": {
-    "coverage": "istanbul cover --report=html jasmine JASMINE_CONFIG_PATH=jasmine.json",
+    "coverage": "istanbul cover --report=cobertura --report=html jasmine JASMINE_CONFIG_PATH=jasmine.json",
     "jscs": "jscs bin lib",
     "jshint": "jshint bin lib",
     "lint": "npm run jshint && npm run jscs",
@@ -41,6 +41,7 @@
   "devDependencies": {
     "istanbul": "0.4.4",
     "jasmine": "2.4.1",
+    "jasmine-reporters": "^2.2.1",
     "jscs": "3.0.7",
     "jshint": "2.9.2",
     "mock-require": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "skyux": "bin/skyux.js"
   },
   "scripts": {
-    "coverage": "istanbul cover --report=cobertura --report=html jasmine JASMINE_CONFIG_PATH=jasmine.json",
+    "coverage": "istanbul cover --report=cobertura --report=html node_modules/jasmine/bin/jasmine.js -- JASMINE_CONFIG_PATH=jasmine.json",
     "jscs": "jscs bin lib",
     "jshint": "jshint bin lib",
     "lint": "npm run jshint && npm run jscs",

--- a/test/jasmine-junit-reporter.spec.js
+++ b/test/jasmine-junit-reporter.spec.js
@@ -1,0 +1,9 @@
+﻿/*jshint jasmine: true, node: true */
+'use strict';
+
+const jasmineReporters = require('jasmine-reporters');
+
+jasmine.getEnv().addReporter(
+    new jasmineReporters.JUnitXmlReporter({
+        savePath: 'testresults'
+    }));


### PR DESCRIPTION
Adds Cobertura and JUnit output to `skyux test`. These coverage and test results reports can be used to represent test results in CI/CD pipelines.