### PR TITLE
Added specific prefix to component library SPAs

### DIFF
--- a/lib/new.js
+++ b/lib/new.js
@@ -201,15 +201,19 @@ const promptForUrl = () => {
 const promptForName = () => {
   const prompt = 'What is the root directory for your SPA? (example: my-spa-name)';
   const validator = (value) => {
+    const packageName = getPackageName(value);
+
     if (!value || !value.match(/^[a-z0-9\-]*$/)) {
       throw new Error(
         'SPA root directories may only contain lower-case letters, numbers or dashes.'
       );
-    } else if (fs.existsSync(path.join('.', 'skyux-spa-' + value))) {
+    } else if (fs.existsSync(path.join('.', packageName))) {
       throw new Error(
         'SPA directory already exists.'
       );
     }
+
+    logger.info(`Creating a new SPA named '${packageName}'.`);
 
     return value;
   };
@@ -217,11 +221,30 @@ const promptForName = () => {
   return promptly.prompt(prompt, { validator: validator })
     .then((value) => {
       settings.spa = value;
-      settings.name = 'skyux-spa-' + value;
+      settings.name = getPackageName(value);
       settings.path = path.join('.', settings.name);
       settings.pathTmp = path.join(settings.path, 'tmp');
       return Promise.resolve(value);
     });
+};
+
+/**
+ * Returns a string to be used for the name property in package.json.
+ * @name getPackageName
+ */
+const getPackageName = (name) => {
+  let prefix;
+
+  switch (settings.template.name) {
+    case 'library':
+      prefix = 'lib';
+      break;
+    default:
+      prefix = 'spa';
+      break;
+  }
+
+  return `skyux-${prefix}-${name}`;
 };
 
 /**

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -81,6 +81,24 @@ describe('skyux new command', () => {
     });
   });
 
+  it('should name the package with a specific prefix depending on the template', (done) => {
+    spyOn(logger, 'info');
+    const libTemplateName = 'library';
+    const skyuxNew = require('../lib/new')({
+      template: libTemplateName
+    });
+    sendLine('some-spa-name', () => {
+      sendLine('', () => {
+        skyuxNew.then(() => {
+          expect(logger.info).toHaveBeenCalledWith(
+            `Creating new SPA named 'skyux-lib-some-spa-name'.`
+          );
+          done();
+        });
+      });
+    });
+  });
+
   it('should clone the default template if template flag is used without a name', (done) => {
     spyOn(logger, 'info');
     const skyuxNew = require('../lib/new')({

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -91,7 +91,7 @@ describe('skyux new command', () => {
       sendLine('', () => {
         skyuxNew.then(() => {
           expect(logger.info).toHaveBeenCalledWith(
-            `Creating new SPA named 'skyux-lib-some-spa-name'.`
+            `Creating a new SPA named 'skyux-lib-some-spa-name'.`
           );
           done();
         });


### PR DESCRIPTION
Typing `skyux new -t library` Should produce a SPA named `skyux-lib-*`.