### PR TITLE
Adjusted glob pattern to support scoped packages locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function processArgv(argv) {
 
   // Look globally and locally for matching glob pattern
   const dirs = [
-    `${process.cwd()}/node_modules`, // local (where they ran the command from)
+    `${process.cwd()}/node_modules/*`, // local (where they ran the command from)
     `${__dirname}/..`,  // global, if scoped package (where this code exists)
     `${__dirname}/../..`, // global, if not scoped package
   ];


### PR DESCRIPTION
This should fix being able to find scoped packages, but still keep it efficient by not searching ALL sub directories.  This also brings up a really good point as to needing integration tests for the CLI, which I'll file a separate issue on. https://github.com/blackbaud/skyux2/issues/1249

To test this locally you can install this branch of builder by using `npm i -g blackbaud/skyux-cli#hotfix-glob-scope` (no `@`).