### PR TITLE
Added support for handling runCommand boolean.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,10 +81,16 @@ function invokeCommand(argv) {
     }
   });
 
+  const modulesAnsweredLength = modulesAnswered.length;
+  const modulesAnsweredPlural = modulesAnsweredLength === 1 ? 'module' : 'modules';
+
   if (modulesAnswered.length === 0) {
     fatal(`No module found for ${command}`);
   } else {
-    logger.verbose(`Successfully passed ${command} to ${modulesAnswered.length} module(s).`);
+    logger.verbose(
+      `Successfully passed ${command} to ${modulesAnsweredLength} ${modulesAnsweredPlural}:`
+    );
+    logger.verbose(modulesAnswered.join(', '));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function invokeCommand(argv) {
   ];
 
   let modulesCalled = {};
+  let modulesAnswered = [];
 
   getGlobs(dirs).forEach(pkg => {
     const dirName = path.dirname(pkg);
@@ -70,14 +71,20 @@ function invokeCommand(argv) {
         logger.verbose(`Multiple instances found. Skipping passing command to ${pkgName}`);
       } else {
         logger.verbose(`Passing command to ${pkgName}`);
-        module.runCommand(command, argv);
+
         modulesCalled[pkgName] = true;
+        if (module.runCommand(command, argv)) {
+          modulesAnswered.push(pkgName);
+        }
+
       }
     }
   });
 
-  if (Object.keys(modulesCalled).length === 0) {
+  if (modulesAnswered.length === 0) {
     fatal(`No module found for ${command}`);
+  } else {
+    logger.verbose(`Successfully passed ${command} to ${modulesAnswered.length} module(s).`);
   }
 }
 

--- a/test/skyux.spec.js
+++ b/test/skyux.spec.js
@@ -180,18 +180,26 @@ describe('skyux CLI', () => {
       mock('local-module', {
         runCommand: (cmd) => {
           expect(cmd).toBe(customCommand);
+
+          // command answered
+          return true;
         }
       });
 
       mock('non-scoped-global-module', {
         runCommand: (cmd) => {
           expect(cmd).toBe(customCommand);
+
+          // unknown command
+          return false;
         }
       });
 
       mock('scoped-global-module', {
         runCommand: (cmd) => {
           expect(cmd).toBe(customCommand);
+
+          // No return (simulating backwards compatability)
         }
       });
 
@@ -199,6 +207,21 @@ describe('skyux CLI', () => {
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to local-module-name`);
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to non-scoped-global-module-name`);
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to scoped-global-module-name`);
+      expect(logger.verbose).toHaveBeenCalledWith(`Successfully passed ${customCommand} to 1 module(s).`)
+    });
+
+    it('should fail and log an error if modules found but unknown command (none return true)', () => {
+      const customCommand = 'customCommand';
+
+      mock('local-module', {
+        runCommand: (cmd) => {
+          expect(cmd).toBe(customCommand);
+          return false;
+        }
+      });
+
+      cli({ _: [customCommand] });
+      expect(logger.error).toHaveBeenCalledWith(`No module found for ${customCommand}`);
     });
 
     it('should handle an error when requiring a malformed module', () => {

--- a/test/skyux.spec.js
+++ b/test/skyux.spec.js
@@ -190,7 +190,45 @@ describe('skyux CLI', () => {
         runCommand: (cmd) => {
           expect(cmd).toBe(customCommand);
 
-          // unknown command
+          // command answered
+          return true;
+        }
+      });
+
+      mock('scoped-global-module', {
+        runCommand: (cmd) => {
+          expect(cmd).toBe(customCommand);
+
+          // command unanswered
+          return false;
+        }
+      });
+
+      cli({ _: [customCommand] });
+      expect(logger.verbose).toHaveBeenCalledWith(`Passing command to local-module-name`);
+      expect(logger.verbose).toHaveBeenCalledWith(`Passing command to non-scoped-global-module-name`);
+      expect(logger.verbose).toHaveBeenCalledWith(`Passing command to scoped-global-module-name`);
+      expect(logger.verbose).toHaveBeenCalledWith(`Successfully passed ${customCommand} to 2 modules:`)
+      expect(logger.verbose).toHaveBeenCalledWith(`local-module-name, non-scoped-global-module-name`);
+    });
+
+    it('should verbosely log the correct plural form of "module"', () => {
+      const customCommand = 'customCommand';
+
+      mock('local-module', {
+        runCommand: (cmd) => {
+          expect(cmd).toBe(customCommand);
+
+          // command answered
+          return true;
+        }
+      });
+
+      mock('non-scoped-global-module', {
+        runCommand: (cmd) => {
+          expect(cmd).toBe(customCommand);
+
+          // command answered
           return false;
         }
       });
@@ -199,7 +237,7 @@ describe('skyux CLI', () => {
         runCommand: (cmd) => {
           expect(cmd).toBe(customCommand);
 
-          // No return (simulating backwards compatability)
+          // No return value
         }
       });
 
@@ -207,7 +245,8 @@ describe('skyux CLI', () => {
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to local-module-name`);
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to non-scoped-global-module-name`);
       expect(logger.verbose).toHaveBeenCalledWith(`Passing command to scoped-global-module-name`);
-      expect(logger.verbose).toHaveBeenCalledWith(`Successfully passed ${customCommand} to 1 module(s).`)
+      expect(logger.verbose).toHaveBeenCalledWith(`Successfully passed ${customCommand} to 1 module:`)
+      expect(logger.verbose).toHaveBeenCalledWith(`local-module-name`);
     });
 
     it('should fail and log an error if modules found but unknown command (none return true)', () => {


### PR DESCRIPTION
Piggy backing off of @Blackbaud-ColbyWhite's recent PR #150 and my original abandoned #131.

In addition to finding modules, this handles the return value from a module's `runCommand`. 

The use-case being, a module is called with a command it doesn't want to / need to answer.  In that case it would return false.  If it is a command it handles, it would return true.